### PR TITLE
Improve storybook UX

### DIFF
--- a/generators/component/templates/view.stories.js.ejs
+++ b/generators/component/templates/view.stories.js.ejs
@@ -5,7 +5,7 @@ import { withKnobs /*, text, boolean, select*/ } from '@storybook/addon-knobs';
 
 import { <%= Name %>View } from './<%= Name %>.view';
 
-const stories = storiesOf('<%= [FeatureName.split('/').join('::'), 'Component'].filter(Boolean).join('::') %>::<%= Name %>::View', module);
+const stories = storiesOf('<%= [FeatureName, 'Component'].filter(Boolean).join('/') %>/<%= Name %>/View', module);
 
 stories.addDecorator(withKnobs);
 

--- a/generators/form/templates/controller.stories.js.ejs
+++ b/generators/form/templates/controller.stories.js.ejs
@@ -5,7 +5,7 @@ import { withKnobs } from '@storybook/addon-knobs';
 
 import { <%= Name %>Controller } from './<%= Name %>.controller';
 
-const stories = storiesOf('<%= [FeatureName.split('/').join('::'), 'Form'].filter(Boolean).join('::') %>::<%= Name %>::Controller', module);
+const stories = storiesOf('<%= [FeatureName, 'Form'].filter(Boolean).join('/') %>/<%= Name %>/Controller', module);
 
 stories.addDecorator(withKnobs);
 

--- a/generators/page/templates/view.stories.js.ejs
+++ b/generators/page/templates/view.stories.js.ejs
@@ -5,7 +5,7 @@ import { withKnobs /*, text, boolean, select*/ } from '@storybook/addon-knobs';
 
 import { <%= Name %>View } from './<%= Name %>.view';
 
-const stories = storiesOf('<%= [FeatureName.split('/').join('::'), 'Page'].filter(Boolean).join('::') %>::<%= Name %>::View', module);
+const stories = storiesOf('<%= [FeatureName, 'Page'].filter(Boolean).join('/') %>/<%= Name %>/View', module);
 
 stories.addDecorator(withKnobs);
 


### PR DESCRIPTION
This change allows to use nesting in stories navigations.
For example, navigation panel will be next:
Before this update:
 - Feature1::Component::Component1
 - Feature1::Component::Component2
 - Feature2::Component::Component3
 - Feature2::Page::Page1
After:
 - Feature1
   - Component
     - Component1
     - Component2
 - Feature2
   - Component
     - Component3
   - Page
     - Page1

The second variant is very comfort in navigation in case of huge
component base.